### PR TITLE
Fix MyLibrary doesn't exist issue

### DIFF
--- a/external_lib_scope/lib/MyLibrary.py
+++ b/external_lib_scope/lib/MyLibrary.py
@@ -1,10 +1,16 @@
-from robot.api import logger
+"""This is a one-line docstring of a module."""
+
 
 class MyLibrary(object):
-    
+    """Demonstrate the result of different test library scope settings."""
+
+    ROBOT_LIBRARY_SCOPE = 'TEST CASE'
+
     def __init__(self):
+        """Constructor of MyLibrary."""
         self.count = 0
-        
+
     def get_count_value(self):
+        """Accumulate count."""
         self.count = self.count + 1
         return self.count

--- a/external_lib_scope/test.txt
+++ b/external_lib_scope/test.txt
@@ -1,5 +1,5 @@
 *** Settings ***
-Library           C:\\Users\\wakevin\\Desktop\\test\\lib\\MyLibrary.py
+Library           lib/MyLibrary.py
 
 *** Test Cases ***
 Test Case 1


### PR DESCRIPTION
1. Correct the path of MyLibrary.
2. Invoke Python coding style check.